### PR TITLE
Add unit tests for storage js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Development
+
+Install NodeJS dependencies:
+```sh
+npm install
+```
+
+Run unit tests:
+```sh
+npm test
+```
+
+Run extension in browser:
+```sh
+./node_modules/.bin/web-ext run --verbose --source-dir ./WebExtension
+```

--- a/WebExtension/lib/chrome.js
+++ b/WebExtension/lib/chrome.js
@@ -26,6 +26,7 @@ function storageWrapper(name){
 	}
 	
 	self.init();
+	return self
 }
 
 function expandUrl(url){
@@ -39,4 +40,9 @@ function isActiveTabPrivate(cb){
 	//	return;
 
 	return  chrome.tabs.query({active: true, lastFocusedWindow: true }, function(tabs){ cb(tabs[0].incognito)}) 
+}
+
+if (typeof window === 'undefined') { // running in node.js
+    module.exports.storageWrapper = storageWrapper;
+} else { // running in browser
 }

--- a/WebExtension/lib/chrome.js
+++ b/WebExtension/lib/chrome.js
@@ -8,21 +8,21 @@ function storageWrapper(name){
 
 	self.init = function(cb){
 		var s = localStorage[storageName];
-		data = s ? JSON.parse(s) : {};
+		self.data = s ? JSON.parse(s) : {};
 		if(cb) cb();
 	};
 
 	self.set = function(key, value){
-		data[key] = value;
+		self.data[key] = value;
 		self.save();
 	}
 	
 	self.get = function(key){
-		return data[key];
+		return self.data[key];
 	}
 
 	self.save = function(){
-		localStorage[storageName] = JSON.stringify(data);
+		localStorage[storageName] = JSON.stringify(self.data);
 	}
 	
 	self.init();

--- a/WebExtension/lib/events.js
+++ b/WebExtension/lib/events.js
@@ -1,7 +1,7 @@
 
 // https://developer.chrome.com/extensions/webRequest#type-RequestFilter
 var beforerequest = function(details) {
-        console.log("beforerequest called details: " + JSON.stringify(details));
+	console.log("beforerequest called details: " + JSON.stringify(details));
 	
 	var url = details.url;
 	//details.url

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -26,7 +26,9 @@
    ],
    
    "background": {
-    "scripts": ["lib/browser-polyfill.js", "lib/storage.js", "lib/util.js", "lib/chrome.js", "lib/whitelist.js", "lib/security.js", "worker.js", "lib/events.js"],
+    "scripts": ["lib/browser-polyfill.js", "lib/storage.js", "lib/util.js",
+    	"lib/chrome.js", "lib/whitelist.js", "lib/security.js", "worker.js",
+    	"lib/events.js"],
     "persistent": true // CHROME ONLY
   }   
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "chai": "^4.1.2",
     "mocha": "^4.0.1",
     "sinon": "^4.1.3",
-    "sinon-chrome": "^2.2.1"
+    "sinon-chrome": "^2.2.1",
+    "web-ext": "^3.0.0"
   },
   "scripts": {
     "test": "mocha"

--- a/test/test_storage.js
+++ b/test/test_storage.js
@@ -64,5 +64,14 @@ describe('storageWrapper test', function() {
     	assert.equal(data["test-key"], "test-value");
     });
 
+    it('get returns what set writes', function() {
+    	var storage = chrome_module.storageWrapper("test storage");
+    	storage.set("test-key", "test-value");
+
+    	actual = storage.get("test-key");
+
+    	assert.equal(actual, "test-value");
+    });
+
 });
 

--- a/test/test_storage.js
+++ b/test/test_storage.js
@@ -7,16 +7,14 @@ describe('storageWrapper test', function() {
         chrome = require('sinon-chrome/extensions');
         browser = require('sinon-chrome/webextensions');
 
-        localStorage = {};
-
         chrome_module = require('../WebExtension/lib/chrome.js');
     });
 
     beforeEach(function() {
+        localStorage = {};
     });
 
     after(function() {
-        localStorage = {};
     });
 
     it('storage calls callback', function() {
@@ -45,6 +43,15 @@ describe('storageWrapper test', function() {
 		actual = storage.get("test-key");
 
     	assert.equal(actual, "test-value");
+    });
+
+    it('set writes to the local storage', function() {
+    	var storage = chrome_module.storageWrapper("test storage");
+
+    	storage.set("test-key", "test-value");
+
+		var data = JSON.parse(localStorage["test storage"]);
+    	assert.equal(data["test-key"], "test-value");
     });
 
 });

--- a/test/test_storage.js
+++ b/test/test_storage.js
@@ -54,5 +54,15 @@ describe('storageWrapper test', function() {
     	assert.equal(data["test-key"], "test-value");
     });
 
+    it('save writes data to the local storage', function() {
+    	var storage = chrome_module.storageWrapper("test storage");
+    	storage.data = { "test-key": "test-value" };
+
+    	storage.save();
+
+		var data = JSON.parse(localStorage["test storage"]);
+    	assert.equal(data["test-key"], "test-value");
+    });
+
 });
 

--- a/test/test_storage.js
+++ b/test/test_storage.js
@@ -28,5 +28,15 @@ describe('storageWrapper test', function() {
         assert.isOk(callback.called);
     });
 
+    it('initialization callback has access to the storage', function() {
+    	var storage = chrome_module.storageWrapper("test storage");
+        localStorage["test storage"] = '{ "test-key": "test-value" }';
+    	var callback = sinon.spy(function() {
+    		assert.equal(storage.get("test-key"), "test-value");
+    	});
+
+    	storage.init(callback);
+    });
+
 });
 

--- a/test/test_storage.js
+++ b/test/test_storage.js
@@ -38,5 +38,14 @@ describe('storageWrapper test', function() {
     	storage.init(callback);
     });
 
+    it('get returns data from local storage', function() {
+        localStorage["test storage"] = '{ "test-key": "test-value" }';
+    	var storage = chrome_module.storageWrapper("test storage");
+
+		actual = storage.get("test-key");
+
+    	assert.equal(actual, "test-value");
+    });
+
 });
 

--- a/test/test_storage.js
+++ b/test/test_storage.js
@@ -1,0 +1,32 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+describe('storageWrapper test', function() {
+
+    before(function () {
+        chrome = require('sinon-chrome/extensions');
+        browser = require('sinon-chrome/webextensions');
+
+        localStorage = {};
+
+        chrome_module = require('../WebExtension/lib/chrome.js');
+    });
+
+    beforeEach(function() {
+    });
+
+    after(function() {
+        localStorage = {};
+    });
+
+    it('storage should call callback', function() {
+    	var callback = sinon.spy();
+    	var storage = chrome_module.storageWrapper("test storage");
+
+    	storage.init(callback);
+
+        assert.isOk(callback.called);
+    });
+
+});
+

--- a/test/test_storage.js
+++ b/test/test_storage.js
@@ -19,7 +19,7 @@ describe('storageWrapper test', function() {
         localStorage = {};
     });
 
-    it('storage should call callback', function() {
+    it('storage calls callback', function() {
     	var callback = sinon.spy();
     	var storage = chrome_module.storageWrapper("test storage");
 


### PR DESCRIPTION
What is done:
- added tests for storage module;
- return self in `storageWrapper()` constructor;
- use `self` inside wrapper to address `data;
- minor whitespace fixes;
- web-ext is added as dependency to test in browser;
- added dev instructions to README.md.
